### PR TITLE
feat: add config for wang2022_rsteer reproduction

### DIFF
--- a/configs/model/wang2022_rsteer.yaml
+++ b/configs/model/wang2022_rsteer.yaml
@@ -1,0 +1,27 @@
+_target_: src.models.wang2022_module.Wang2022LightningModule
+
+optimizer:
+  _target_: torch.optim.Adam
+  _partial_: true
+  lr: 0.001
+  weight_decay: 0.0004
+  betas: [0.9, 0.999]
+
+scheduler:
+  _target_: torch.optim.lr_scheduler.StepLR
+  _partial_: true
+  step_size: 1
+  gamma: 0.9
+
+net:
+  _target_: src.models.components.wang2022.rsteer.Relaxed_Rot_SteerConvNet
+  in_frames: 1
+  out_frames: 1
+  hidden_dim: 32
+  kernel_size: 3 
+  num_layers: 5
+  N: 4
+  alpha: 0
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/src/models/components/gcnn/rsteer_rotation.py
+++ b/src/models/components/gcnn/rsteer_rotation.py
@@ -2,47 +2,82 @@ import torch
 from src.models.components.gcnn.steerable.relaxed_rotation_steer import (
     Relaxed_Rot_SteerConv,
 )
+import torch.nn.functional as F
+
 
 class Relaxed_Rot_SteerConvNet(torch.nn.Module):
-    def __init__(self, in_frames, out_frames, hidden_dim, kernel_size, num_layers, N, alpha = 1):
+    def __init__(
+        self, in_frames, out_frames, hidden_dim, kernel_size, num_layers, N, alpha=1
+    ):
         super(Relaxed_Rot_SteerConvNet, self).__init__()
         self.alpha = alpha
 
-        layers = [Relaxed_Rot_SteerConv(in_frames = in_frames, out_frames = hidden_dim, 
-                                 kernel_size = kernel_size, N = N, 
-                                 first_layer = True, last_layer = False)]
-        
-        layers += [Relaxed_Rot_SteerConv(in_frames = hidden_dim, out_frames = hidden_dim, 
-                                  kernel_size = kernel_size, N = N, 
-                                  first_layer = False, last_layer = False) 
-                   for i in range(num_layers-2)]
-        
-        layers += [Relaxed_Rot_SteerConv(in_frames = hidden_dim, out_frames = out_frames, 
-                                  kernel_size = kernel_size, N = N, 
-                                  first_layer = False, last_layer = True) ]
+        layers = [
+            Relaxed_Rot_SteerConv(
+                in_frames=in_frames,
+                out_frames=hidden_dim,
+                kernel_size=kernel_size,
+                N=N,
+                first_layer=True,
+                last_layer=False,
+            )
+        ]
+
+        layers += [
+            Relaxed_Rot_SteerConv(
+                in_frames=hidden_dim,
+                out_frames=hidden_dim,
+                kernel_size=kernel_size,
+                N=N,
+                first_layer=False,
+                last_layer=False,
+            )
+            for i in range(num_layers - 2)
+        ]
+
+        layers += [
+            Relaxed_Rot_SteerConv(
+                in_frames=hidden_dim,
+                out_frames=out_frames,
+                kernel_size=kernel_size,
+                N=N,
+                first_layer=False,
+                last_layer=True,
+            )
+        ]
         self.model = torch.nn.Sequential(*layers)
-        
+
     def rot_vector(self, inp, theta):
-        #inp shape: c x 2 x 64 x 64
+        # inp shape: c x 2 x 64 x 64
         theta = torch.tensor(theta).float()
-        rot_matrix = torch.tensor([[torch.cos(theta), -torch.sin(theta)], [torch.sin(theta), torch.cos(theta)]]).float()
-        out = torch.einsum("ab, bc... -> ac...",(rot_matrix, inp.transpose(0,1))).transpose(0,1)
+        rot_matrix = torch.tensor(
+            [
+                [torch.cos(theta), -torch.sin(theta)],
+                [torch.sin(theta), torch.cos(theta)],
+            ]
+        ).float()
+        out = torch.einsum(
+            "ab, bc... -> ac...", (rot_matrix, inp.transpose(0, 1))
+        ).transpose(0, 1)
         return out
-    
+
     def get_rot_mat(self, theta):
         theta = torch.tensor(theta).float()
-        return torch.tensor([[torch.cos(theta), -torch.sin(theta), 0],
-                             [torch.sin(theta), torch.cos(theta), 0]]).float()
+        return torch.tensor(
+            [
+                [torch.cos(theta), -torch.sin(theta), 0],
+                [torch.sin(theta), torch.cos(theta), 0],
+            ]
+        ).float()
 
     def rot_img(self, x, theta):
-        rot_mat = self.get_rot_mat(theta)[None, ...].float().repeat(x.shape[0],1,1)
+        rot_mat = self.get_rot_mat(theta)[None, ...].float().repeat(x.shape[0], 1, 1)
         grid = F.affine_grid(rot_mat, x.size()).float()
         x = F.grid_sample(x, grid)
         return x.float()
-   
+
     def get_weight_constraint(self):
         return self.alpha * sum([layer.get_weight_constraint() for layer in self.model])
-    
-        
+
     def forward(self, xx):
         return self.model(xx)

--- a/src/models/components/gcnn/steerable/relaxed_rotation_steer.py
+++ b/src/models/components/gcnn/steerable/relaxed_rotation_steer.py
@@ -1,65 +1,87 @@
-import torch
 import e2cnn
 import numpy as np
+import torch
 import torch.nn as nn
-from e2cnn.nn.modules.r2_conv.r2convolution import compute_basis_params
+import torch.nn.functional as F
 from e2cnn.nn.modules.r2_conv.basisexpansion_singleblock import block_basisexpansion
+from e2cnn.nn.modules.r2_conv.r2convolution import compute_basis_params
+
 
 class Relaxed_Rot_SteerConv(torch.nn.Module):
-    def __init__(self, in_frames, out_frames, kernel_size, N, first_layer = False, last_layer = False):
+    def __init__(
+        self, in_frames, out_frames, kernel_size, N, first_layer=False, last_layer=False
+    ):
         super(Relaxed_Rot_SteerConv, self).__init__()
-        r2_act = e2cnn.gspaces.Rot2dOnR2(N = N)
+        r2_act = e2cnn.gspaces.Rot2dOnR2(N=N)
         self.last_layer = last_layer
         self.first_layer = first_layer
         self.kernel_size = kernel_size
-        
+
         if self.first_layer:
-            self.feat_type_in = e2cnn.nn.FieldType(r2_act, in_frames*[r2_act.irrep(1)])
+            self.feat_type_in = e2cnn.nn.FieldType(
+                r2_act, in_frames * [r2_act.irrep(1)]
+            )
         else:
-            self.feat_type_in = e2cnn.nn.FieldType(r2_act, in_frames*[r2_act.regular_repr])
-            
+            self.feat_type_in = e2cnn.nn.FieldType(
+                r2_act, in_frames * [r2_act.regular_repr]
+            )
+
         if self.last_layer:
-            self.feat_type_hid = e2cnn.nn.FieldType(r2_act, out_frames*[r2_act.irrep(1)])
+            self.feat_type_hid = e2cnn.nn.FieldType(
+                r2_act, out_frames * [r2_act.irrep(1)]
+            )
         else:
-            self.feat_type_hid = e2cnn.nn.FieldType(r2_act, out_frames*[r2_act.regular_repr])
-            
+            self.feat_type_hid = e2cnn.nn.FieldType(
+                r2_act, out_frames * [r2_act.regular_repr]
+            )
+
         if not last_layer:
             self.norm = e2cnn.nn.InnerBatchNorm(self.feat_type_hid)
             self.relu = e2cnn.nn.ReLU(self.feat_type_hid)
-        
-        
-        grid, basis_filter, rings, sigma, maximum_frequency = compute_basis_params(kernel_size = kernel_size)
+
+        grid, basis_filter, rings, sigma, maximum_frequency = compute_basis_params(
+            kernel_size=kernel_size
+        )
         i_repr = self.feat_type_in._unique_representations.pop()
         o_repr = self.feat_type_hid._unique_representations.pop()
-        basis = self.feat_type_in.gspace.build_kernel_basis(i_repr, o_repr, sigma, rings, maximum_frequency = 5)
-        block_expansion = block_basisexpansion(basis, grid, basis_filter, recompute=False)
+        basis = self.feat_type_in.gspace.build_kernel_basis(
+            i_repr, o_repr, sigma, rings, maximum_frequency=5
+        )
+        block_expansion = block_basisexpansion(
+            basis, grid, basis_filter, recompute=False
+        )
 
-        
         self.basis_kernels = block_expansion.sampled_basis
-        
-        
-        stdv = np.sqrt(1/(in_frames*kernel_size*kernel_size))
-        self.relaxed_weights = nn.Parameter(torch.ones(out_frames, self.basis_kernels.shape[0], in_frames, kernel_size**2).float())
+
+        stdv = np.sqrt(1 / (in_frames * kernel_size * kernel_size))
+        self.relaxed_weights = nn.Parameter(
+            torch.ones(
+                out_frames, self.basis_kernels.shape[0], in_frames, kernel_size**2
+            ).float()
+        )
         self.relaxed_weights.data.uniform_(-stdv, stdv)
 
-        self.bias = nn.Parameter(torch.zeros(out_frames*self.basis_kernels.shape[1]))
+        self.bias = nn.Parameter(torch.zeros(out_frames * self.basis_kernels.shape[1]))
         self.bias.data.uniform_(-stdv, stdv)
-        
-        # self.relaxed_weights = nn.Parameter(torch.ones(out_frames, self.basis_kernels.shape[0], in_frames, kernel_size**2).float().to(device)/self.basis_kernels.shape[0]/(kernel_size**2))
-        # self.bias = nn.Parameter(torch.zeros(out_frames*self.basis_kernels.shape[1]).to(device))
 
-        
     def get_weight_constraint(self):
-        return torch.mean(torch.abs(self.relaxed_weights[...,:-1] - self.relaxed_weights[...,1:])) #torch.roll()
+        return torch.mean(
+            torch.abs(self.relaxed_weights[..., :-1] - self.relaxed_weights[..., 1:])
+        )
 
     def forward(self, x):
-        conv_filters = torch.einsum('bpqk,obik->opiqk', self.basis_kernels, self.relaxed_weights) 
-        conv_filters = conv_filters.reshape(conv_filters.shape[0]*conv_filters.shape[1],
-                                            conv_filters.shape[2]*conv_filters.shape[3], 
-                                            self.kernel_size, self.kernel_size)
-        
+        conv_filters = torch.einsum(
+            "bpqk,obik->opiqk", self.basis_kernels, self.relaxed_weights
+        )
+        conv_filters = conv_filters.reshape(
+            conv_filters.shape[0] * conv_filters.shape[1],
+            conv_filters.shape[2] * conv_filters.shape[3],
+            self.kernel_size,
+            self.kernel_size,
+        )
+
         if not self.last_layer:
-            out = F.conv2d(x, conv_filters, self.bias, padding = 1)
-            return self.relu(e2cnn.nn.GeometricTensor(out, self.feat_type_hid)).tensor#self.norm(
+            out = F.conv2d(x, conv_filters, self.bias, padding=1)
+            return self.relu(e2cnn.nn.GeometricTensor(out, self.feat_type_hid)).tensor
         else:
-            return F.conv2d(x, conv_filters, self.bias, padding = 1)
+            return F.conv2d(x, conv_filters, self.bias, padding=1)

--- a/src/models/components/wang2022/rsteer.py
+++ b/src/models/components/wang2022/rsteer.py
@@ -1,0 +1,1 @@
+from src.models.components.gcnn.rsteer_rotation import Relaxed_Rot_SteerConvNet


### PR DESCRIPTION
## Tasks
- [x] Adds config file for wang2022_rsteer
- [x] Verifies that notebook rsteer and #41 rsteer are the same, provides import at `src.models.components.wang2022.rsteer` too